### PR TITLE
Handle an extension which is an empty string

### DIFF
--- a/NiceIO.Tests/ChangeExtension.cs
+++ b/NiceIO.Tests/ChangeExtension.cs
@@ -32,5 +32,13 @@ namespace NiceIO.Tests
 			var p2 = new NPath("/my/path/file.something.mp4").ChangeExtension(".txt");
 			Assert.AreEqual(p1, p2);
 		}
+
+		[Test]
+		public void ToEmptyString()
+		{
+			var expected = new NPath("/my/path/file.something");
+			var actual = new NPath("/my/path/file.something.exe").ChangeExtension(string.Empty);
+			Assert.AreEqual(expected, actual);
+		}
 	}
 }

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -121,6 +121,8 @@ namespace NiceIO
 		{
 			var newElements = (string[])_elements.Clone();
 			newElements[newElements.Length - 1] = Path.ChangeExtension(_elements[_elements.Length - 1], WithDot(extension));
+			if (extension == string.Empty)
+				newElements[newElements.Length - 1] = newElements[newElements.Length - 1].TrimEnd('.');
 			return new NPath(newElements, _isRelative, _driveLetter);
 		}
 		#endregion construction


### PR DESCRIPTION
Don't leave a trailing dot when an extension is changed to be an empty
string. This can happen with an executable on a Unix-like system, for
example.
