### PR TITLE
RelativeTo now supports non-child path cases (case 867613)

### DIFF
--- a/NiceIO.Tests/Combine.cs
+++ b/NiceIO.Tests/Combine.cs
@@ -41,5 +41,11 @@ namespace NiceIO.Tests
 		{
 			Assert.AreEqual(new NPath("/a/b/c/d/e"), new NPath("/a").Combine("b", "c/d", "e"));
 		}
+
+		[Test]
+		public void RelativeThatGoesAboveRoot()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("/a").Combine(new NPath("../../b")));
+		}
 	}
 }

--- a/NiceIO.Tests/Contents.cs
+++ b/NiceIO.Tests/Contents.cs
@@ -92,41 +92,5 @@ namespace NiceIO.Tests
 		{
 			Assert.That(new NPath("my/path/is/kind/of/long").Depth, Is.EqualTo(6));
 		}
-
-		[Test]
-		public void SameVolumeAsWindowsPathOnSame()
-		{
-			Assert.That(new NPath("C:\\my\\path").SameVolumeAs(new NPath("C:\\")), Is.True);
-		}
-
-		[Test]
-		public void SameVolumeAsWindowsPathOnDifferent()
-		{
-			Assert.That(new NPath("C:\\my\\path").SameVolumeAs(new NPath("E:\\")), Is.False);
-		}
-
-		[Test]
-		public void SameVolumeAsLinuxPath()
-		{
-			Assert.That(new NPath("/my/path").SameVolumeAs(new NPath("/my")), Is.True);
-		}
-
-		[Test]
-		public void SameVolumeAsBothRelative()
-		{
-			Assert.Throws<ArgumentException>(() => new NPath("my/path").SameVolumeAs(new NPath("my")));
-		}
-
-		[Test]
-		public void SameVolumeAsThisRelative()
-		{
-			Assert.Throws<ArgumentException>(() => new NPath("my/path").SameVolumeAs(new NPath("/my")));
-		}
-
-		[Test]
-		public void SameVolumeAsOtherRelative()
-		{
-			Assert.Throws<ArgumentException>(() => new NPath("/my/path").SameVolumeAs(new NPath("my")));
-		}
 	}
 }

--- a/NiceIO.Tests/Contents.cs
+++ b/NiceIO.Tests/Contents.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -72,6 +73,60 @@ namespace NiceIO.Tests
 			CollectionAssert.AreEquivalent(new[] { "myfile.txt", "source.cpp" }, currentDirRelative.Files(recurse: true).Select(p => p.FileName));
 
 			Directory.SetCurrentDirectory(originalCurrentDirectory);
+		}
+
+		[Test]
+		public void DepthWindowsPath()
+		{
+			Assert.That(new NPath("C:\\my\\path\\is\\kind\\of\\long").Depth, Is.EqualTo(6));
+		}
+
+		[Test]
+		public void DepthLinuxPath()
+		{
+			Assert.That(new NPath("/my/path/is/kind/of/long").Depth, Is.EqualTo(6));
+		}
+
+		[Test]
+		public void DepthRelativePath()
+		{
+			Assert.That(new NPath("my/path/is/kind/of/long").Depth, Is.EqualTo(6));
+		}
+
+		[Test]
+		public void SameVolumeAsWindowsPathOnSame()
+		{
+			Assert.That(new NPath("C:\\my\\path").SameVolumeAs(new NPath("C:\\")), Is.True);
+		}
+
+		[Test]
+		public void SameVolumeAsWindowsPathOnDifferent()
+		{
+			Assert.That(new NPath("C:\\my\\path").SameVolumeAs(new NPath("E:\\")), Is.False);
+		}
+
+		[Test]
+		public void SameVolumeAsLinuxPath()
+		{
+			Assert.That(new NPath("/my/path").SameVolumeAs(new NPath("/my")), Is.True);
+		}
+
+		[Test]
+		public void SameVolumeAsBothRelative()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("my/path").SameVolumeAs(new NPath("my")));
+		}
+
+		[Test]
+		public void SameVolumeAsThisRelative()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("my/path").SameVolumeAs(new NPath("/my")));
+		}
+
+		[Test]
+		public void SameVolumeAsOtherRelative()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("/my/path").SameVolumeAs(new NPath("my")));
 		}
 	}
 }

--- a/NiceIO.Tests/Parent.cs
+++ b/NiceIO.Tests/Parent.cs
@@ -49,6 +49,17 @@ namespace NiceIO.Tests
 		}
 
 		[Test]
+		public void RelativeRecursiveParentsStartFromFile()
+		{
+			var path = new NPath("mydir/myotherdir/myfile.exe");
+
+			var result = path.RecursiveParents.ToArray();
+
+			Assert.That(result[0], Is.EqualTo(path.Parent));
+			Assert.That(result[1], Is.EqualTo(path.Parent.Parent));
+		}
+
+		[Test]
 		[Platform(Include = "Win")]
 		public void RecursiveParentsStartFromFileAllTheWayToRoot()
 		{

--- a/NiceIO.Tests/RelativeTo.cs
+++ b/NiceIO.Tests/RelativeTo.cs
@@ -41,13 +41,55 @@ namespace NiceIO.Tests
 		[Test]
 		public void ToAnUnrelatedDirectory()
 		{
-			Assert.Throws<ArgumentException>(() => new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/unrelated")));
+			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/unrelated"));
+			Assert.AreEqual("../mydir1/mydir2/myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
 		}
 
 		[Test]
 		public void RootOfDrive()
 		{
 			Assert.IsFalse(new NPath("D:\\").IsRelative);
+		}
+
+		[Test]
+		public void WhenNotAChildSameLevel()
+		{
+			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/mydir1/mydir2/mydir3"));
+			Assert.AreEqual("../myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
+		}
+
+		[Test]
+		public void WhenNotAChildSameLevelAndRelative()
+		{
+			var relative = new NPath("mydir1/mydir2/myfile").RelativeTo(new NPath("mydir1/mydir2/mydir3"));
+			Assert.AreEqual("../myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
+		}
+
+		[Test]
+		public void WhenNotAChildParentLevel()
+		{
+			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/mydir1/mydir3"));
+			Assert.AreEqual("../mydir2/myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
+		}
+
+		[Test]
+		public void WhenNotAChildAndManyParentLevels()
+		{
+			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/mydir1/mydir3/mydir3.1/mydir3.2/mydir3.3/mydir3.4"));
+			Assert.AreEqual("../../../../../mydir2/myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
+		}
+
+		[Test]
+		public void WhenNotAChildAndManySubDirLevels()
+		{
+			var relative = new NPath("/mydir1/mydir2/mydir2.1/mydir2.2/mydir2.3/mydir2.4/myfile").RelativeTo(new NPath("/mydir1/mydir3"));
+			Assert.AreEqual("../mydir2/mydir2.1/mydir2.2/mydir2.3/mydir2.4/myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
 		}
 	}
 }

--- a/NiceIO.Tests/RelativeTo.cs
+++ b/NiceIO.Tests/RelativeTo.cs
@@ -39,6 +39,12 @@ namespace NiceIO.Tests
 		}
 
 		[Test]
+		public void RelativeAndRelativeNoCommonParent()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("mydir1/mydir2/myfile").RelativeTo(new NPath("somethingelse")).ToString(SlashMode.Forward));
+		}
+
+		[Test]
 		public void ToAnUnrelatedDirectory()
 		{
 			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/unrelated"));

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -113,7 +113,7 @@ namespace NiceIO
 		{
 			if (!IsChildOf(path))
 			{
-				if (!IsRelative && !path.IsRelative && !SameVolumeAs(path))
+				if (!IsRelative && !path.IsRelative && _driveLetter != path._driveLetter)
 					throw new ArgumentException("Path.RelativeTo() was invoked with two paths that are on different volumes. invoked on: " + ToString() + " asked to be made relative to: " + path);
 
 				NPath commonParent = null;
@@ -648,14 +648,6 @@ namespace NiceIO
 				return true;
 
 			return Parent.IsChildOf(potentialBasePath);
-		}
-
-		public bool SameVolumeAs(NPath path)
-		{
-			ThrowIfRelative();
-			path.ThrowIfRelative();
-
-			return _driveLetter == path._driveLetter;
 		}
 
 		public IEnumerable<NPath> RecursiveParents

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -117,7 +117,7 @@ namespace NiceIO
 					throw new ArgumentException("Path.RelativeTo() was invoked with two paths that are on different volumes. invoked on: " + ToString() + " asked to be made relative to: " + path);
 
 				NPath commonParent = null;
-				foreach(var parent in RecursiveParents)
+				foreach (var parent in RecursiveParents)
 				{
 					commonParent = path.RecursiveParents.FirstOrDefault(otherParent => otherParent == parent);
 

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -128,6 +128,9 @@ namespace NiceIO
 				if (commonParent == null)
 					throw new ArgumentException("Path.RelativeTo() was unable to find a common parent between " + ToString() + " and " + path);
 
+				if (IsRelative && path.IsRelative && commonParent.IsEmpty())
+					throw new ArgumentException("Path.RelativeTo() was invoked with two relative paths that do not share a common parent.  Invoked on: " + ToString() + " asked to be made relative to: " + path);
+
 				var depthDiff = path.Depth - commonParent.Depth;
 				return new NPath(Enumerable.Repeat("..", depthDiff).Concat(_elements.Skip(commonParent.Depth)).ToArray(), true, null);
 			}


### PR DESCRIPTION
* RecursiveParents no longer blocked for relative paths
* Depth property
* SameVolumeAs method