### PR TITLE
Root directory handling fixes and improvements

### DIFF
--- a/NiceIO.Tests/ChangeExtension.cs
+++ b/NiceIO.Tests/ChangeExtension.cs
@@ -40,5 +40,17 @@ namespace NiceIO.Tests
 			var actual = new NPath("/my/path/file.something.exe").ChangeExtension(string.Empty);
 			Assert.AreEqual(expected, actual);
 		}
+
+		[Test]
+		public void BlockedOnWindowsRoot()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("C:\\").ChangeExtension(".txt"));
+		}
+
+		[Test]
+		public void BlockedOnLinuxRoot()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("/").ChangeExtension(".txt"));
+		}
 	}
 }

--- a/NiceIO.Tests/Combine.cs
+++ b/NiceIO.Tests/Combine.cs
@@ -47,5 +47,17 @@ namespace NiceIO.Tests
 		{
 			Assert.Throws<ArgumentException>(() => new NPath("/a").Combine(new NPath("../../b")));
 		}
+
+		[Test]
+		public void CombineWithLinuxRoot()
+		{
+			Assert.AreEqual(new NPath("/somedir"), new NPath("/").Combine("somedir"));
+		}
+
+		[Test]
+		public void CombineWithWindowsRoot()
+		{
+			Assert.AreEqual(new NPath("C:\\somedir"), new NPath("C:\\").Combine("somedir"));
+		}
 	}
 }

--- a/NiceIO.Tests/Combine.cs
+++ b/NiceIO.Tests/Combine.cs
@@ -59,5 +59,17 @@ namespace NiceIO.Tests
 		{
 			Assert.AreEqual(new NPath("C:\\somedir"), new NPath("C:\\").Combine("somedir"));
 		}
+
+		[Test]
+		public void CombineResultingInWindowsRootIsRoot()
+		{
+			Assert.IsTrue(new NPath("C:\\somedir").Combine("..").IsRoot);
+		}
+
+		[Test]
+		public void CombineResultingInLinuxRootIsRoot()
+		{
+			Assert.IsTrue(new NPath("/somedir").Combine("..").IsRoot);
+		}
 	}
 }

--- a/NiceIO.Tests/Construction.cs
+++ b/NiceIO.Tests/Construction.cs
@@ -116,13 +116,53 @@ namespace NiceIO.Tests
 		[Test]
 		public void ConstructionOfAbsolutePathWithDotDotsWindowsStyle()
 		{
-			Assert.AreEqual("c:\\this\\is\\yet_can_have_dots", new NPath("c:\\this\\is\\so\\absolute\\..\\..\\yet_can_have_dots").ToString());
+			var value = new NPath("c:\\this\\is\\so\\absolute\\..\\..\\yet_can_have_dots");
+			Assert.AreEqual(3, value.Depth);
+			Assert.AreEqual("c:\\this\\is\\yet_can_have_dots", value.ToString());
 		}
 
 		[Test]
 		public void ConstructionOfAbsolutePathWithDotDotsLinuxStyle()
 		{
-			Assert.AreEqual("/this/is/yet_can_have_dots", new NPath("/this/is/so/absolute/../../yet_can_have_dots").ToString(SlashMode.Forward));
+			var value = new NPath("/this/is/so/absolute/../../yet_can_have_dots");
+			Assert.AreEqual(3, value.Depth);
+			Assert.AreEqual("/this/is/yet_can_have_dots", value.ToString(SlashMode.Forward));
+		}
+
+		[Test]
+		public void WindowsRootDirectoryIsRoot()
+		{
+			Assert.IsTrue(new NPath("C:\\").IsRoot);
+		}
+
+		[Test]
+		public void WindowsDirectoryIsNotRoot()
+		{
+			Assert.IsFalse(new NPath("C:\\somedir").IsRoot);
+		}
+
+		[Test]
+		public void WindowsRootViaParentIsRoot()
+		{
+			Assert.IsTrue(new NPath("C:\\somedir").Parent.IsRoot);
+		}
+
+		[Test]
+		public void LinuxRootDirectoryIsRoot()
+		{
+			Assert.IsTrue(new NPath("/").IsRoot);
+		}
+
+		[Test]
+		public void LinuxDirectoryIsNotRoot()
+		{
+			Assert.IsFalse(new NPath("/somedir").IsRoot);
+		}
+
+		[Test]
+		public void LinuxRootViaParentIsRoot()
+		{
+			Assert.IsTrue(new NPath("/somedir").Parent.IsRoot);
 		}
 	}
 }

--- a/NiceIO.Tests/Construction.cs
+++ b/NiceIO.Tests/Construction.cs
@@ -104,7 +104,7 @@ namespace NiceIO.Tests
 		[Test]
 		public void WindowsRootDirectory()
 		{
-			Assert.AreEqual("C:\\", new NPath("C:\\").ToString());
+			Assert.AreEqual("C:\\", new NPath("C:\\").ToString(SlashMode.Backward));
 		}
 
 		[Test]
@@ -118,7 +118,7 @@ namespace NiceIO.Tests
 		{
 			var value = new NPath("c:\\this\\is\\so\\absolute\\..\\..\\yet_can_have_dots");
 			Assert.AreEqual(3, value.Depth);
-			Assert.AreEqual("c:\\this\\is\\yet_can_have_dots", value.ToString());
+			Assert.AreEqual("c:\\this\\is\\yet_can_have_dots", value.ToString(SlashMode.Backward));
 		}
 
 		[Test]

--- a/NiceIO.Tests/Construction.cs
+++ b/NiceIO.Tests/Construction.cs
@@ -86,7 +86,31 @@ namespace NiceIO.Tests
 		[Test]
 		public void WithEmptyString()
 		{
-			Assert.AreEqual(".", new NPath("").ToString());
+			Assert.AreEqual(".", new NPath("").ToString(SlashMode.Forward));
+		}
+
+		[Test]
+		public void LinuxRootDirectory()
+		{
+			Assert.AreEqual("/", new NPath("/").ToString(SlashMode.Forward));
+		}
+
+		[Test]
+		public void LinuxRootDirectoryIsNotRelative()
+		{
+			Assert.IsFalse(new NPath("/").IsRelative);
+		}
+
+		[Test]
+		public void WindowsRootDirectory()
+		{
+			Assert.AreEqual("C:\\", new NPath("C:\\").ToString());
+		}
+
+		[Test]
+		public void WindowsRootDirectoryIsNotRelative()
+		{
+			Assert.IsFalse(new NPath("C:\\").IsRelative);
 		}
 	}
 }

--- a/NiceIO.Tests/Construction.cs
+++ b/NiceIO.Tests/Construction.cs
@@ -164,5 +164,17 @@ namespace NiceIO.Tests
 		{
 			Assert.IsTrue(new NPath("/somedir").Parent.IsRoot);
 		}
+
+		[Test]
+		public void RelativePathWithSingleParentParentIsNotRoot()
+		{
+			Assert.IsFalse(new NPath("somedir").Parent.IsRoot);
+		}
+
+		[Test]
+		public void RelativePathParentIsNotRoot()
+		{
+			Assert.IsFalse(new NPath("somedir1/somedir2/somedir3").Parent.IsRoot);
+		}
 	}
 }

--- a/NiceIO.Tests/Construction.cs
+++ b/NiceIO.Tests/Construction.cs
@@ -112,5 +112,17 @@ namespace NiceIO.Tests
 		{
 			Assert.IsFalse(new NPath("C:\\").IsRelative);
 		}
+
+		[Test]
+		public void ConstructionOfAbsolutePathWithDotDotsWindowsStyle()
+		{
+			Assert.AreEqual("c:\\this\\is\\yet_can_have_dots", new NPath("c:\\this\\is\\so\\absolute\\..\\..\\yet_can_have_dots").ToString());
+		}
+
+		[Test]
+		public void ConstructionOfAbsolutePathWithDotDotsLinuxStyle()
+		{
+			Assert.AreEqual("/this/is/yet_can_have_dots", new NPath("/this/is/so/absolute/../../yet_can_have_dots").ToString(SlashMode.Forward));
+		}
 	}
 }

--- a/NiceIO.Tests/ExtensionWithDot.cs
+++ b/NiceIO.Tests/ExtensionWithDot.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace NiceIO.Tests
 {
@@ -21,6 +22,24 @@ namespace NiceIO.Tests
 		public void FileWithMultipleDots()
 		{
 			Assert.AreEqual(".exe", new NPath("myfile.something.something.exe").ExtensionWithDot);
+		}
+
+		[Test]
+		public void ExtensionWithDotOnLinuxRoot()
+		{
+			Assert.Throws<ArgumentException>(() =>
+			{
+				var result = new NPath("/").ExtensionWithDot;
+			});
+		}
+
+		[Test]
+		public void ExtensionWithDotOnWindowsRoot()
+		{
+			Assert.Throws<ArgumentException>(() =>
+			{
+				var result = new NPath("C:\\").ExtensionWithDot;
+			});
 		}
 	}
 }

--- a/NiceIO.Tests/IsChildOf.cs
+++ b/NiceIO.Tests/IsChildOf.cs
@@ -54,13 +54,13 @@ namespace NiceIO.Tests
 		[Test]
 		public void WindowsPathIsChildOfLinuxRoot()
 		{
-			Assert.Throws<ArgumentException>(() => new NPath("C:\\hello\\there").IsChildOf(new NPath("/")));
+			Assert.IsFalse(new NPath("C:\\hello\\there").IsChildOf(new NPath("/")));
 		}
 
 		[Test]
 		public void LinuxPathIsChildOfWindowsRoot()
 		{
-			Assert.Throws<ArgumentException>(() => new NPath("/hello/there").IsChildOf(new NPath("C:\\")));
+			Assert.IsFalse(new NPath("/hello/there").IsChildOf(new NPath("C:\\")));
 		}
 	}
 }

--- a/NiceIO.Tests/IsChildOf.cs
+++ b/NiceIO.Tests/IsChildOf.cs
@@ -51,5 +51,10 @@ namespace NiceIO.Tests
 			Assert.IsFalse(new NPath("hello/there").IsChildOf(new NPath("boink")));
 		}
 
+		[Test]
+		public void WindowsPathIsChildOfLinuxRoot()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("C:\\hello\\there").IsChildOf(new NPath("/")));
+		}
 	}
 }

--- a/NiceIO.Tests/IsChildOf.cs
+++ b/NiceIO.Tests/IsChildOf.cs
@@ -56,5 +56,11 @@ namespace NiceIO.Tests
 		{
 			Assert.Throws<ArgumentException>(() => new NPath("C:\\hello\\there").IsChildOf(new NPath("/")));
 		}
+
+		[Test]
+		public void LinuxPathIsChildOfWindowsRoot()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("/hello/there").IsChildOf(new NPath("C:\\")));
+		}
 	}
 }

--- a/NiceIO.Tests/Parent.cs
+++ b/NiceIO.Tests/Parent.cs
@@ -35,6 +35,18 @@ namespace NiceIO.Tests
 		}
 
 		[Test]
+		public void RecursiveParentsStartFromFileToRoot()
+		{
+			var path = new NPath("/mydir/myotherdir/myfile");
+
+			var result = path.RecursiveParents.ToArray();
+
+			Assert.That(result[0], Is.EqualTo(new NPath("/mydir/myotherdir")));
+			Assert.That(result[1], Is.EqualTo(new NPath("/mydir")));
+			Assert.That(result[2], Is.EqualTo(new NPath("/")));
+		}
+
+		[Test]
 		public void RecursiveParentsStartFromFile()
 		{
 			var path = NPath.CurrentDirectory.Combine("mydir/myotherdir/myfile.exe");

--- a/NiceIO.Tests/RelativeTo.cs
+++ b/NiceIO.Tests/RelativeTo.cs
@@ -75,6 +75,18 @@ namespace NiceIO.Tests
 		}
 
 		[Test]
+		public void WindowsPathRelativeToLinuxRootThrows()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("C:\\mydir1\\mydir2\\myfile").RelativeTo(new NPath("/")));
+		}
+
+		[Test]
+		public void LinuxPathRelativeToWindowsRootThrows()
+		{
+			Assert.Throws<ArgumentException>(() => new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("C:\\")));
+		}
+
+		[Test]
 		public void WhenNotAChildSameLevel()
 		{
 			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/mydir1/mydir2/mydir3"));

--- a/NiceIO.Tests/RelativeTo.cs
+++ b/NiceIO.Tests/RelativeTo.cs
@@ -59,6 +59,22 @@ namespace NiceIO.Tests
 		}
 
 		[Test]
+		public void PathRelativeWindowsRoot()
+		{
+			var relative = new NPath("C:\\mydir1\\mydir2\\myfile").RelativeTo(new NPath("C:\\"));
+			Assert.AreEqual("mydir1\\mydir2\\myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
+		}
+
+		[Test]
+		public void PathRelativeLinuxRoot()
+		{
+			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/"));
+			Assert.AreEqual("mydir1/mydir2/myfile", relative.ToString(SlashMode.Forward));
+			Assert.IsTrue(relative.IsRelative);
+		}
+
+		[Test]
 		public void WhenNotAChildSameLevel()
 		{
 			var relative = new NPath("/mydir1/mydir2/myfile").RelativeTo(new NPath("/mydir1/mydir2/mydir3"));

--- a/NiceIO.Tests/RelativeTo.cs
+++ b/NiceIO.Tests/RelativeTo.cs
@@ -62,7 +62,7 @@ namespace NiceIO.Tests
 		public void PathRelativeWindowsRoot()
 		{
 			var relative = new NPath("C:\\mydir1\\mydir2\\myfile").RelativeTo(new NPath("C:\\"));
-			Assert.AreEqual("mydir1\\mydir2\\myfile", relative.ToString(SlashMode.Forward));
+			Assert.AreEqual("mydir1\\mydir2\\myfile", relative.ToString());
 			Assert.IsTrue(relative.IsRelative);
 		}
 

--- a/NiceIO.Tests/RelativeTo.cs
+++ b/NiceIO.Tests/RelativeTo.cs
@@ -62,7 +62,7 @@ namespace NiceIO.Tests
 		public void PathRelativeWindowsRoot()
 		{
 			var relative = new NPath("C:\\mydir1\\mydir2\\myfile").RelativeTo(new NPath("C:\\"));
-			Assert.AreEqual("mydir1\\mydir2\\myfile", relative.ToString());
+			Assert.AreEqual("mydir1\\mydir2\\myfile", relative.ToString(SlashMode.Backward));
 			Assert.IsTrue(relative.IsRelative);
 		}
 

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -45,6 +45,9 @@ namespace NiceIO
 			if (elements.Length == 0 && !isRelative && string.IsNullOrEmpty(driveLetter))
 				_isLinuxRoot = true;
 
+			if (_isLinuxRoot && _isRelative)
+				throw new ArgumentException("_isRelative cannot be true when _isLinuxRoot is also true");
+
 			_elements = elements;
 			_isRelative = isRelative;
 			_driveLetter = driveLetter;

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -134,9 +134,7 @@ namespace NiceIO
 				}
 
 				if (commonParent == null)
-				{
 					throw new ArgumentException("Path.RelativeTo() was unable to find a common parent between " + ToString() + " and " + path);
-				}
 
 				if (IsRelative && path.IsRelative && commonParent.IsEmpty())
 					throw new ArgumentException("Path.RelativeTo() was invoked with two relative paths that do not share a common parent.  Invoked on: " + ToString() + " asked to be made relative to: " + path);
@@ -254,7 +252,7 @@ namespace NiceIO
 		public string ToString(SlashMode slashMode)
 		{
 			// Check if it's linux root /
-			if (_elements.Length == 0 && !_isRelative && string.IsNullOrEmpty(_driveLetter))
+			if (IsRoot && string.IsNullOrEmpty(_driveLetter))
 				return Slash(slashMode).ToString();
 
 			if (_isRelative && _elements.Length == 0)


### PR DESCRIPTION
* Fix Linux root directory handling.  Was broken in most cases.  Would be treated as "." by mistake

* Fix Windows root directory handling, was broken in a smaller subset of cases

* Add tests for construction of paths that are absolute, but have '..'s in in.  These tests were passing without requiring any changes

* Block certain file related operations on root directories

* Block destructive operations on root directories.  There's really no need for them, and given that linux root's were previously treated as '.', allowing a destructive operation could lead to a very bad bug