### PR TITLE
Changes to make NiceIO compliant with netstd1.6

### DIFF
--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -608,7 +608,7 @@ namespace NiceIO
 			{
 				if (Path.DirectorySeparatorChar == '\\')
 					return new NPath(Environment.GetEnvironmentVariable("USERPROFILE"));
-				return new NPath(Environment.GetFolderPath(Environment.SpecialFolder.Personal));
+				return new NPath(Environment.GetEnvironmentVariable("HOME"));
 			}
 		}
 

--- a/NiceIO.cs
+++ b/NiceIO.cs
@@ -8,7 +8,7 @@ namespace NiceIO
 {
 	public class NPath : IEquatable<NPath>, IComparable
 	{
-		private static readonly StringComparison PathStringComparison = IsLinux() ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
+		private static readonly StringComparison PathStringComparison = IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
 		private readonly string[] _elements;
 		private readonly bool _isRelative;


### PR DESCRIPTION
With these few harmless changes, NiceIO becomes compliant with netstandard1.6

I'm not an expert on StringComparison, but based on my understanding of the recommendations here : https://msdn.microsoft.com/en-us/library/dd465121.aspx using Ordinal compare actually sounds like a slight better option than Invariant (which does not exist in netstd1.6)

il2cpp's version of NiceIO needs to be compliant with netstd1.6.  In order to do that, we have had these few changes in il2cpp's copy of NiceIO for months.  Keeping these only in the il2cpp copy of NiceIO.cs makes keeping NiceIO in sync harder since you can't just copy over the latest NiceIO.cs from github.

