### PR TITLE
Convert NPath to struct and abstract away all filesystem operations

### DIFF
--- a/NiceIO.Tests/Combine.cs
+++ b/NiceIO.Tests/Combine.cs
@@ -37,6 +37,12 @@ namespace NiceIO.Tests
 		}
 
 		[Test]
+		public void CombiningDotDotOntoRelativePathWithDotDot()
+		{
+			Assert.AreEqual(new NPath("../other/myfile"), new NPath("../parent/somedir/somedir2").Combine(new NPath("../../../other/myfile")));
+		}
+
+		[Test]
 		public void WithMultipleArguments()
 		{
 			Assert.AreEqual(new NPath("/a/b/c/d/e"), new NPath("/a").Combine("b", "c/d", "e"));

--- a/NiceIO.Tests/ParentContaining.cs
+++ b/NiceIO.Tests/ParentContaining.cs
@@ -13,7 +13,7 @@ namespace NiceIO.Tests
 		[Test]
 		public void TwoLevelsDown()
 		{
-			PopulateTempDir(new [] { "somedir/","somedir/dir2/","somedir/dir2/myfile", "somedir/needle"});
+			PopulateTempDir(new[] { "somedir/", "somedir/dir2/", "somedir/dir2/myfile", "somedir/needle" });
 
 			Assert.AreEqual(_tempPath.Combine("somedir"), _tempPath.Combine("somedir/dir2/myfile").ParentContaining("needle"));
 		}
@@ -23,13 +23,15 @@ namespace NiceIO.Tests
 		{
 			PopulateTempDir(new[] { "somedir/", "somedir/dir2/", "somedir/dir2/myfile" });
 
-			Assert.IsNull(_tempPath.Combine("somedir/dir2/myfile").ParentContaining("nonexisting"));
+			var nonExistingParent = _tempPath.Combine("somedir/dir2/myfile").ParentContaining("nonexisting");
+			Assert.IsFalse(nonExistingParent.IsInitialized);
+			Assert.AreEqual(NPath.Default, nonExistingParent);
 		}
 
 		[Test]
 		public void WithComplexNeedle()
 		{
-			PopulateTempDir(new[] { "somedir/", "somedir/dir2/", "somedir/dir2/myfile" ,"needledir/","needledir/needlefile"});
+			PopulateTempDir(new[] { "somedir/", "somedir/dir2/", "somedir/dir2/myfile", "needledir/", "needledir/needlefile" });
 
 			Assert.AreEqual(_tempPath, _tempPath.Combine("somedir/dir2/myfile").ParentContaining(new NPath("needledir/needlefile")));
 		}

--- a/NiceIO.Tests/TestWithTempDir.cs
+++ b/NiceIO.Tests/TestWithTempDir.cs
@@ -12,13 +12,16 @@ namespace NiceIO.Tests
 		[SetUp]
 		public void Setup()
 		{
+			NPath.FileSystem = new FileSystem();
 			_tempPath = NPath.CreateTempDirectory("NiceIOTest");
+			NPath.FileSystem.SetCurrentDirectory(_tempPath);
 		}
 
 		[TearDown]
 		public void TearDown()
 		{
 			_tempPath.Delete();
+			NPath.FileSystem = null;
 		}
 
 		protected void PopulateTempDir(string[] entries)


### PR DESCRIPTION
:wave:

This takes out all System.IO calls from inside NPath and into a `FileSystem` class/interface. This allows the entire filesystem to be mocked and also allows setting the current directory at any time.

Over at GitHub for Unity we've been adding a bunch of functionality that we find useful to NPath, like `Read/WriteAllBytes`, `GetCommonParent` and `GetTempFile`, so that's in here too. There's also a `Resolve` method to resolve symlink paths on non-Windows systems when you really need to know the real path, and a fix for `GetHashCode` (it wasn't taking case sensitivity into account on Windows)

I also went ahead and converted the whole thing to a struct, felt like the right thing to do 😄
