### PR TITLE
NiceIO as a source-only package :D

### DIFF
--- a/NiceIO.PackageTest/Extension.cs
+++ b/NiceIO.PackageTest/Extension.cs
@@ -1,0 +1,6 @@
+namespace AnotherNamespace;
+
+partial class NPath
+{
+	public static NPath AnotherStatic => new("a/b/c");
+}

--- a/NiceIO.PackageTest/NiceIO.PackageTest.csproj
+++ b/NiceIO.PackageTest/NiceIO.PackageTest.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PreprocessorValue Include="NICEIO_NAMESPACE" Value="AnotherNamespace" Visible="false" />
+    <PackageReference Include="NiceIO" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/NiceIO.PackageTest/Program.cs
+++ b/NiceIO.PackageTest/Program.cs
@@ -1,0 +1,2 @@
+﻿var path = AnotherNamespace.NPath.AnotherStatic.Combine("file.txt");
+Console.WriteLine($"Path is {path}");

--- a/NiceIO.PackageTest/nuget.config
+++ b/NiceIO.PackageTest/nuget.config
@@ -1,0 +1,5 @@
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="packages"/>
+  </config>
+</configuration>

--- a/NiceIO.PackageTest/test.ps1
+++ b/NiceIO.PackageTest/test.ps1
@@ -1,0 +1,5 @@
+dotnet pack .. -p:NuspecFile=NiceIO.nuspec
+dotnet add package NiceIO --source ..\bin\release --package-directory packages
+if ((dotnet run) -ne 'Path is a/b/c/file.txt') { throw 'it broke' }
+''
+'Everything is shiny'

--- a/NiceIO.csproj
+++ b/NiceIO.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9</LangVersion>
@@ -8,4 +8,20 @@
   <ItemGroup>
     <Compile Include="NiceIO.cs"/>
   </ItemGroup>
+
+  <!-- macro-ize the namespace, and make class partial so package users can add statics -->
+  <!-- usage: `dotnet pack -p:NuspecFile=NiceIO.nuspec` -->
+  
+  <Target Name="PrePack" BeforeTargets="GenerateNuspec"> <!-- we're not actually using the generated nuspec, but this is a convenient spot to generate the .pp -->
+    <WriteLinesToFile
+      File="obj/pack/NiceIO.cs.pp"
+      Lines="$(
+        [System.IO.File]::ReadAllText('NiceIO.cs')
+          .Replace('namespace NiceIO','namespace $NICEIO_NAMESPACE$')
+          .Replace('NiceIO.','$NICEIO_NAMESPACE$.')
+          .Replace('class NPath','partial class NPath') 
+        )"
+      Overwrite="true">
+    </WriteLinesToFile>
+  </Target>
 </Project>

--- a/NiceIO.nuspec
+++ b/NiceIO.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- this needs to be done as a nuspec rather than generated from the csproj because
+     generation will mark the .pp in the generated .nuspec as "buildAction=none", which
+     prevents the project trying to compile with it. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd">
+  <metadata>
+    <id>NiceIO</id>
+    <version>1.0.0</version>
+    <title>NiceIO</title>
+    <description>For when you've had to use System.IO one time too many.</description>
+    <authors>Lucas Meijer</authors>
+    <repository type="git" url="https://github.com/lucasmeijer/NiceIO" />
+    <license type="expression">MIT</license>
+    <readme>README.md</readme>
+    <contentFiles>
+    </contentFiles>
+  </metadata>
+  <files>
+    <file src="README.md" />
+    <file src="obj/pack/NiceIO.cs.pp" target="contentFiles/cs/netstandard2.0/NiceIO.cs.pp" />
+  </files>
+</package>

--- a/NiceIO.sln
+++ b/NiceIO.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -6,6 +6,8 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiceIO", "NiceIO.csproj", "{A3B15020-F3E0-40E6-B3E5-F851255F424F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiceIO.Tests", "NiceIO.Tests\NiceIO.Tests.csproj", "{AC76E796-A1C5-44D7-84F5-88BFD0908767}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiceIO.PackageTest", "NiceIO.PackageTest\NiceIO.PackageTest.csproj", "{7BA16958-FDAE-411E-9EE2-81563B3D4A69}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
NiceIO as a source-only package gives two great tastes that taste great together:

1. It's a package! Add to any project with nuget commands/ui, do easy version upgrades.
2. It's still source! There's no DLL, it's directly compiled into whatever project references it.

A user would do this:

* `dotnet add package NiceIO` or do the search+add thing in the UI.
* Decide whether or not to republish by setting `NICEIO_PUBLIC` (same behavior as now).
* Set the namespace to put `NPath` in by adding to the .csproj in an `ItemGroup`:
  `<PreprocessorValue Include="NICEIO_NAMESPACE" Value="YourNamespaceHere" Visible="false" />`
* Make a new `partial class NPath` file and add statics or whatever, if they want.

Some implementation notes:

* I don't love the required `PreprocessorValue` thing. There's probably some nuget package magic that can add a `PreprocessorValue` automatically..I have seen nuget packages modify the csproj they become a part of, but didn't look into it.
* Another option for the `.cs.pp` is `$rootnamespace$`, which requires no configuration, but is more limited in that it depends on the csproj root namespace setting. Nuget's substitution stuff is really limited. Tradeoffs..
* README should probably say something about the package and give the "use" instructions above. I can do an update there too in this PR if you want.
* I have very little experience with nuget packages so the .nuspec is probably needing some attention.

What do you think?
